### PR TITLE
Console locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 ## 1.0.3
 
 * Add indefinite spinner
+
+## 1.0.4
+
+* Add console lock for InlineProgressBar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@
 
 ## 1.0.4
 
-* Add console lock for asynchronous console writes
+* Add console lock for during console writes on separate threads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@
 
 ## 1.0.4
 
-* Add console lock for InlineProgressBar
+* Add console lock for asynchronous console writes

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ which will look something like this:
 
 ### Asynchronous console updates
 
-A lock object can be optionally passed into each spinner thingie's constructor. This allows you to lock around spinner updates when there are console writes occuring on other threads.
+A lock object can be optionally passed into each spinner thingie's constructor. This allows you to lock around spinner updates when there are console writes occurring on other threads.
 
 
 # License

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ which will look something like this:
 	|                           | Downloading 1,11 MB |<<<<<                       |
 	
 
+### Asynchronous console updates
+
+A lock object can be optionally passed into each spinner thingie's constructor. This allows you to lock around spinner updates when there are console writes occuring on other threads.
+
+
 # License
 
 [The MIT License (MIT)](http://opensource.org/licenses/MIT)

--- a/Spinnerino/IndefiniteProgressBar.cs
+++ b/Spinnerino/IndefiniteProgressBar.cs
@@ -12,17 +12,18 @@ namespace Spinnerino
             RightToLeft
         }
 
-        readonly Timer _timer = new Timer(35);
-        readonly char _moverChar;
-        readonly char _backgroundChar;
-        readonly ProgressDirection _direction;
-        readonly int _moverWidth;
-        readonly int _bufferWidth;
-        readonly int _cursorTop;
+        private readonly Timer _timer = new Timer(35);
+        private readonly char _moverChar;
+        private readonly char _backgroundChar;
+        private readonly ProgressDirection _direction;
+        private readonly int _moverWidth;
+        private readonly int _bufferWidth;
+        private readonly int _cursorTop;
+        private object _consoleLock;
 
-        string _action = "";
+        private string _action = "";
 
-        public IndefiniteProgressBar(char moverChar = '=', char backgroundChar = '-', int? moverWidth = null, ProgressDirection direction = ProgressDirection.LeftToRight)
+        public IndefiniteProgressBar(char moverChar = '=', char backgroundChar = '-', int? moverWidth = null, ProgressDirection direction = ProgressDirection.LeftToRight, object consoleLock = null)
         {
             _moverChar = moverChar;
             _backgroundChar = backgroundChar;
@@ -36,12 +37,21 @@ namespace Spinnerino
 
             _bufferWidth = Console.BufferWidth;
             _cursorTop = Console.CursorTop;
+            _consoleLock = consoleLock;
+
+            if (_consoleLock == null)
+            {
+                _consoleLock = new object();
+            }
 
             var tick = 0;
 
             _timer.Elapsed += (o, ea) =>
             {
-                Print(_action, tick);
+                lock (_consoleLock)
+                {
+                    Print(_action, tick);
+                }
 
                 tick++;
             };
@@ -53,7 +63,7 @@ namespace Spinnerino
             _action = description?.Trim() ?? "";
         }
 
-        void Print(string action, int tick = -1)
+        private void Print(string action, int tick = -1)
         {
             Console.CursorTop = _cursorTop;
             Console.CursorLeft = 0;

--- a/Spinnerino/IndefiniteSpinner.cs
+++ b/Spinnerino/IndefiniteSpinner.cs
@@ -7,21 +7,28 @@ namespace Spinnerino
 {
     public class IndefiniteSpinner : IDisposable
     {
-        static readonly char[] DefaultChars = @"/-\|".ToCharArray();
-        readonly char[] _chars;
-        readonly bool _newlineWhenDone;
-        readonly Timer _timer = new Timer(65);
-        readonly int _initialCursorLeft = Console.CursorLeft;
+        private static readonly char[] DefaultChars = @"/-\|".ToCharArray();
+        private readonly char[] _chars;
+        private readonly bool _newlineWhenDone;
+        private readonly Timer _timer = new Timer(65);
+        private readonly int _initialCursorLeft = Console.CursorLeft;
+        private readonly int _cursorLeft;
+        private object _consoleLock;
 
         /// <summary>
         /// Constructs the spinner. Optionally by setting <paramref name="newlineWhenDone"/> to true the spinner will go to a new line when it is done.
         /// The sequence of animated characters can be customized by setting <paramref name="animationCharacters"/> - default is the classic /-|\ sequence.
         /// </summary>
-        public IndefiniteSpinner(bool newlineWhenDone = true, IEnumerable<char> animationCharacters = null)
+        public IndefiniteSpinner(bool newlineWhenDone = true, IEnumerable<char> animationCharacters = null, object consoleLock = null)
         {
             _newlineWhenDone = newlineWhenDone;
-
             _chars = (animationCharacters ?? DefaultChars).ToArray();
+            _consoleLock = consoleLock;
+
+            if (_consoleLock == null)
+            {
+                _consoleLock = new object();
+            }
 
             var characterIndex = 0;
 
@@ -29,7 +36,10 @@ namespace Spinnerino
             {
                 var c = _chars[characterIndex % _chars.Length];
 
-                Print(c);
+                lock (consoleLock)
+                {
+                    Print(c);
+                }
 
                 characterIndex++;
             };
@@ -44,7 +54,7 @@ namespace Spinnerino
             Print(' ', newline: true);
         }
 
-        void Print(char c, bool newline = false)
+        private void Print(char c, bool newline = false)
         {
             Console.CursorLeft = _initialCursorLeft;
             Console.Write($"{c}");
@@ -54,6 +64,5 @@ namespace Spinnerino
                 Console.WriteLine();
             }
         }
-
     }
 }

--- a/Spinnerino/IndefiniteSpinner.cs
+++ b/Spinnerino/IndefiniteSpinner.cs
@@ -36,7 +36,7 @@ namespace Spinnerino
             {
                 var c = _chars[characterIndex % _chars.Length];
 
-                lock (consoleLock)
+                lock (_consoleLock)
                 {
                     Print(c);
                 }

--- a/Spinnerino/InlineProgressBar.cs
+++ b/Spinnerino/InlineProgressBar.cs
@@ -6,30 +6,39 @@ namespace Spinnerino
 {
     public class InlineProgressBar : IDisposable, IProgressPercentageIndicator
     {
-        readonly int _width;
-        readonly char _completedChar;
-        readonly char _notCompletedChar;
-        readonly Timer _timer = new Timer(65);
-        readonly int _cursorLeft;
+        private readonly int _width;
+        private readonly char _completedChar;
+        private readonly char _notCompletedChar;
+        private readonly Timer _timer = new Timer(65);
+        private readonly int _cursorLeft;
+        private double _progress;
+        private object _consoleLock;
 
-        double _progress;
-
-        public InlineProgressBar(int width = 10, char completedChar = '#', char notCompletedChar = '-')
+        public InlineProgressBar(int width = 10, char completedChar = '#', char notCompletedChar = '-', object consoleLock = null)
         {
             _width = width;
             _completedChar = completedChar;
             _notCompletedChar = notCompletedChar;
             _cursorLeft = Console.CursorLeft;
+            _consoleLock = consoleLock;
+
+            if (_consoleLock == null)
+            {
+                _consoleLock = new object();
+            }
 
             _timer.Elapsed += (o, ea) =>
             {
-                Print(_progress);
+                lock (consoleLock)
+                {
+                    Print(_progress);
+                }
             };
 
             _timer.Start();
         }
 
-        void Print(double progress)
+        private void Print(double progress)
         {
             Console.CursorLeft = _cursorLeft;
 

--- a/Spinnerino/InlineProgressBar.cs
+++ b/Spinnerino/InlineProgressBar.cs
@@ -29,7 +29,7 @@ namespace Spinnerino
 
             _timer.Elapsed += (o, ea) =>
             {
-                lock (consoleLock)
+                lock (_consoleLock)
                 {
                     Print(_progress);
                 }

--- a/Spinnerino/ProgressBar.cs
+++ b/Spinnerino/ProgressBar.cs
@@ -7,15 +7,16 @@ namespace Spinnerino
 {
     public class ProgressBar : IDisposable, IProgressPercentageIndicator
     {
-        readonly Timer _timer = new Timer(65);
-        readonly char _completedChar;
-        readonly char _notCompletedChar;
-        readonly int _bufferWidth;
-        readonly int _cursorTop;
+        private readonly Timer _timer = new Timer(65);
+        private readonly char _completedChar;
+        private readonly char _notCompletedChar;
+        private readonly int _bufferWidth;
+        private readonly int _cursorTop;
+        private double _progress;
+        private object _consoleLock;
 
-        double _progress;
+        public ProgressBar(char completedChar = '=', char notCompletedChar = '-', object consoleLock = null)
 
-        public ProgressBar(char completedChar = '=', char notCompletedChar = '-')
         {
             _completedChar = completedChar;
             _notCompletedChar = notCompletedChar;
@@ -26,15 +27,25 @@ namespace Spinnerino
 
             _bufferWidth = Console.BufferWidth;
             _cursorTop = Console.CursorTop;
+            _consoleLock = consoleLock;
+
+            if (_consoleLock == null)
+            {
+                _consoleLock = new object();
+            }
 
             _timer.Elapsed += (o, ea) =>
             {
-                Print(_progress);
+                lock (_consoleLock)
+                {
+                    Print(_progress);
+                }
             };
+
             _timer.Start();
         }
 
-        void Print(double progress)
+        private void Print(double progress)
         {
             Console.CursorTop = _cursorTop;
             Console.CursorLeft = 0;


### PR DESCRIPTION
A lock object can be optionally passed into each spinner thingie's constructor. This allows you to lock around spinner updates when there are console writes occurring on other threads.